### PR TITLE
Restore webassembly support

### DIFF
--- a/src/Yaapii.Http/Responses/Synced.cs
+++ b/src/Yaapii.Http/Responses/Synced.cs
@@ -23,6 +23,8 @@
 using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Yaapii.Atoms.Map;
 
@@ -44,7 +46,8 @@ namespace Yaapii.Http.Responses
             {
                 try
                 {
-                    return AsyncContext.Run(() => response);
+                    return 
+                        RuntimeInformation.OSDescription == "Browser" ? response.Result : AsyncContext.Run(() => response);
                 }
                 catch (AggregateException ex)
                 {

--- a/src/Yaapii.Http/Wires/AspNetCoreWire.cs
+++ b/src/Yaapii.Http/Wires/AspNetCoreWire.cs
@@ -24,6 +24,7 @@ using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Yaapii.Atoms;
 using Yaapii.Atoms.Bytes;
@@ -183,7 +184,13 @@ namespace Yaapii.Http.Wires
 
         private HttpResponseMessage AspNetResponse(HttpRequestMessage request)
         {
-            return AsyncContext.Run(() => this.clients.Client(this.timeout).SendAsync(request));
+            var response = this.clients.Client(this.timeout).SendAsync(request);
+            return
+                RuntimeInformation.OSDescription == "Browser"
+                ?
+                response.Result
+                :
+                AsyncContext.Run(() => response);
         }
 
         private HttpContent Content(IDictionary<string, string> request)

--- a/src/Yaapii.Http/Wires/Retry.cs
+++ b/src/Yaapii.Http/Wires/Retry.cs
@@ -28,6 +28,7 @@ using Yaapii.Http.Parts;
 using Yaapii.Http.Parts.Uri;
 using System.Threading.Tasks;
 using Nito.AsyncEx;
+using System.Runtime.InteropServices;
 
 namespace Yaapii.Http.Wires
 {
@@ -75,7 +76,12 @@ namespace Yaapii.Http.Wires
             {
                 try
                 {
-                    response = AsyncContext.Run(() => origin.Response(request));
+                    response =
+                        RuntimeInformation.OSDescription == "Browser"
+                        ?
+                        origin.Response(request).Result
+                        :
+                        AsyncContext.Run(() => origin.Response(request));
                 }
                 catch (Exception ex)
                 {

--- a/src/Yaapii.Http/Wires/Verified.cs
+++ b/src/Yaapii.Http/Wires/Verified.cs
@@ -22,6 +22,7 @@
 
 using Nito.AsyncEx;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Yaapii.Http.Wires
@@ -36,7 +37,13 @@ namespace Yaapii.Http.Wires
         /// </summary>
         public Verified(IWire origin, IVerification verification) : base(request =>
         {
-            var response = AsyncContext.Run(() => origin.Response(request));
+            var response =
+                RuntimeInformation.OSDescription == "Browser"
+                ?
+                origin.Response(request).Result
+                :
+                AsyncContext.Run(() => origin.Response(request));
+
             verification.Verify(response);
             return new TaskFactory().StartNew<IDictionary<string, string>>(() => response);
         })


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds (VisualStudio & cake script: build.ps1)
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
When the library is used in webassemblies, requests fail because awaiting multithreading is not supported in browsers.

### What is the new behavior?
Detection of runtime before syncing a response task so that different sync mechanism can be used.
closes #104 

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information
