### PR TITLE
Refactor HttpMock to use Kestrel instead of MockHttpServer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -359,9 +359,14 @@ See the ```HttpMock``` example code below for more examples of how to use these 
 
 #### HttpMock
 Should you need to test with actual http requests, a mock server is provided through ```HttpMock```.
-It encapsulates [jrharmon's MockHttpServer](https://github.com/jrharmon/MockHttpServer) in a way that allows it to process incoming requests using an ```IWire```.
-It's an ```IScalar``` (see Yaapii.Atoms) returning a ```MockServer``` (see MockHttpServer). 
+It allows it to process incoming requests using an ```IWire```.
+In versions up to 6.0.0, it used [jrharmon's MockHttpServer](https://github.com/jrharmon/MockHttpServer).
+In newer versions, it uses an ASP.NET Kestrel server.
+It's an ```IScalar``` (see Yaapii.Atoms) returning an ```IWebHost``` (see Microsoft.AspNetCore.Hosting). 
 Calling ```HttpMock.Value()``` for the first time will initialize the server.
+
+If an error occurs while processing a request, it responds with a status 500 and writes the exception and its stacktrace into the body of the response.
+
 It can either use one wire to handle all requests, regardless of the requested path, or respond to specific paths with a different wire for each path.
 Routing is done using the ```MatchingWire``` and templates described above.
 ```csharp
@@ -403,9 +408,9 @@ using( var server =
 }
 ```
 
-**Always dispose the ```HttpMock``` or the ```MockServer``` it returned!**
+**Always dispose the ```HttpMock``` or the ```IWebHost``` it returned!**
 
-No need to dispose both, disposing ```HttpMock``` will just dispose the ```MockServer``` returned by ```HttpMock.Value()```.
+No need to dispose both, disposing ```HttpMock``` will just dispose the ```IWebHost``` returned by ```HttpMock.Value()```.
 This means calling ```HttpMock.Dispose()``` will do the same thing as calling ```HttpMock.Value().Dispose()```.
 If not disposed, it will keep running in the background, listening for requests, keeping the port occupied.
 The easiest way to do this is to put either ```new HttpMock``` or ```HttpMock.Value()``` in a using block as follows:
@@ -426,7 +431,6 @@ using( var server =
     ).Value() // start the server immediately
 )
 {
-    var port = server.Port;
     // ... testing code goes here
 } // this disposes the server
 ```

--- a/src/Yaapii.Http.Mock/HttpMock.cs
+++ b/src/Yaapii.Http.Mock/HttpMock.cs
@@ -20,11 +20,16 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-using MockHttpServer;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
+using System.Threading.Tasks;
 using Yaapii.Atoms;
 using Yaapii.Atoms.Enumerable;
 using Yaapii.Atoms.IO;
@@ -44,59 +49,30 @@ namespace Yaapii.Http.Mock
     /// Hosts a local http server for unit testing.
     /// Handles incoming requests using the given wires.
     /// </summary>
-    public sealed class HttpMock : IScalar<MockServer>, IDisposable
+    public sealed class HttpMock : IScalar<IWebHost>, IDisposable
     {
-        private readonly IScalar<MockServer> server;
-        private readonly IWire wire;
+        private readonly IScalar<IWebHost> server;
 
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles incoming requests using the first wire template that matches the request.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
-        /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
-        /// </summary>
-        public HttpMock(int port, string hostname, params ITemplate[] templates) : this(
-            port,
-            new MatchingWire(templates),
-            hostname
-        )
-        { }
-
-        /// <summary>
-        /// Hosts a local http server for unit testing.
-        /// Handles incoming requests using the first wire template that matches the request.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
         public HttpMock(int port, params ITemplate[] templates) : this(
             port,
-            new MatchingWire(templates),
-            "localhost"
+            new MatchingWire(templates)
         )
         { }
 
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
-        /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
-        /// </summary>
-        public HttpMock(int port, string hostname, string path, IWire wire) : this(
-            port,
-            hostname,
-            new KvpOf<IWire>(path, wire)
-        )
-        { }
-
-        /// <summary>
-        /// Hosts a local http server for unit testing.
-        /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
         public HttpMock(int port, string path, IWire wire) : this(
             port,
-            "localhost",
             new KvpOf<IWire>(path, wire)
         )
         { }
@@ -104,72 +80,50 @@ namespace Yaapii.Http.Mock
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
         public HttpMock(int port, params IKvp<IWire>[] pathWirePairs) : this(
             port, 
-            new ManyOf<IKvp<IWire>>(pathWirePairs),
-            "localhost"
+            new ManyOf<IKvp<IWire>>(pathWirePairs)
         )
         { }
 
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
-        public HttpMock(int port, string hostName, params IKvp<IWire>[] pathWirePairs) : this(
+        public HttpMock(int port, IEnumerable<IKvp<IWire>> pathWirePairs) : this(
             port,
-            new ManyOf<IKvp<IWire>>(pathWirePairs),
-            hostName
+            new MapOf<IWire>(pathWirePairs)
         )
         { }
 
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
-        public HttpMock(int port, IEnumerable<IKvp<IWire>> pathWirePairs, string hostName = "localhost") : this(
+        public HttpMock(int port, IDictionary<string, IWire> wires) : this(
             port,
-            new MapOf<IWire>(pathWirePairs),
-            hostName
-        )
-        { }
-
-        /// <summary>
-        /// Hosts a local http server for unit testing.
-        /// Handles incoming requests using the wire specified for that path.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
-        /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
-        /// </summary>
-        public HttpMock(int port, IDictionary<string, IWire> wires, string hostName = "localhost") : this(
-            port,
-            new MatchingWire(wires),
-            hostName
+            new MatchingWire(wires)
         )
         { }
 
         /// <summary>
         /// Hosts a local http server for unit testing.
         /// Handles all incoming requests using the given wire.
-        /// Always dispose this or the returned <see cref="MockServer"/> after use.
+        /// Always dispose this or the returned <see cref="IWebHost"/> after use.
         /// DO NOT use a wire that will send a http request (like AspNetCoreWire), that would just forward incoming requests, potentially causing an infinite loop.
         /// </summary>
-        public HttpMock(int port, IWire wire, string hostName = "localhost")
+        public HttpMock(int port, IWire wire)
         {
-            this.wire = wire;
-            this.server = 
-                new ScalarOf<MockServer>(() =>
-                    new MockServer(
-                        port,
-                        "{}", // match any path
-                        (req, res, prm) => Respond(req, res),
-                        hostName
-                    )
+            this.server =
+                new ScalarOf<IWebHost>(() =>
+                    RunServer(port, wire)
                 );
         }
 
@@ -178,27 +132,81 @@ namespace Yaapii.Http.Mock
             this.server.Value().Dispose();
         }
 
-        public MockServer Value()
+        public IWebHost Value()
         {
             return this.server.Value();
         }
 
-        private async void Respond(HttpListenerRequest request, HttpListenerResponse response)
+        private IWebHost RunServer(int port, IWire wire)
         {
-            var wireResponse = new Response(this.wire, Request(request));
-
-            response.StatusCode = new Status.Of(wireResponse).AsInt();
-            response.StatusDescription = new Reason.Of(wireResponse).AsString();
-            foreach (var header in new Headers.Of(wireResponse))
-            {
-                response.Header(header.Key(), header.Value());
-            }
-            SendBody(response, wireResponse);
+            return
+                WebHost.CreateDefaultBuilder()
+                    .UseKestrel((opt) =>
+                        opt.ListenAnyIP(port)
+                    )
+                    .Configure((app) =>
+                        app.Run((httpContext) =>
+                            Task.Run(() => Respond(httpContext, wire))
+                        )
+                    ).Start();
         }
 
-        private void SendBody(HttpListenerResponse aspNetResponse, IMessage wireResponse)
+        private void Respond(HttpContext httpContext, IWire wire)
         {
-            using (var stream = aspNetResponse.OutputStream)
+            var response = httpContext.Response;
+            IMessage wireResponse;
+            try
+            {
+                wireResponse =
+                    wire.Response(
+                        Request(httpContext.Request)
+                    ).Result;
+                WriteHeaders(response, wireResponse); // done inside the try so the stacktrace is written to the response if an invalid header name causes an error
+            }
+            catch (Exception ex)
+            {
+                response.Headers.Clear();
+                wireResponse =
+                    new SimpleMessage(
+                        new Status(500),
+                        new TextBody(ex.ToString())
+                    );
+            }
+            WriteStatus(response, wireResponse);
+            WriteBody(response, wireResponse);
+        }
+
+        private void WriteHeaders(HttpResponse aspNetResponse, IMessage wireResponse)
+        {
+            foreach (var header in new Headers.Of(wireResponse))
+            {
+                aspNetResponse.Headers.Append(
+                    header.Key(),
+                    header.Value()
+                );
+            }
+        }
+
+        private void WriteStatus(HttpResponse aspNetResponse, IMessage wireResponse)
+        {
+            if (new Status.Exists(wireResponse).Value())
+            {
+                aspNetResponse.StatusCode = new Status.Of(wireResponse).AsInt();
+            }
+
+            var responseFeature = aspNetResponse.HttpContext.Features.Get<IHttpResponseFeature>();
+            if (
+                new Reason.Exists(wireResponse).Value()
+                && responseFeature != null // may be null because http/2 doesn't have reason phrases
+            )
+            {
+                responseFeature.ReasonPhrase = new Reason.Of(wireResponse).AsString();
+            }
+        }
+
+        private void WriteBody(HttpResponse aspNetResponse, IMessage wireResponse)
+        {
+            using (var stream = aspNetResponse.BodyWriter.AsStream())
             {
                 var formParams = new FormParams.Of(wireResponse);
                 if (formParams.Count > 0)
@@ -221,30 +229,89 @@ namespace Yaapii.Http.Mock
             }
         }
 
-        private IMessage Request(HttpListenerRequest request)
+        private IMessage Request(HttpRequest request)
         {
             return
                 new Request(
-                    new Method(request.HttpMethod.ToLower()),
-                    new Address(request.Url),
-                    new Headers(request.Headers),
+                    new Method(request.Method.ToLower()),
+                    RequestAddress(request),
+                    new Headers(
+                        RequestHeaders(request)
+                    ),
                     new Parts.Conditional(
-                        () => request.HasEntityBody,
-                        new Body(
+                        () => (
+                                (request.ContentLength ?? 0) > 0
+                                || (request.ContentType ?? "") != ""
+                            )
+                            && !request.HasFormContentType,
+                        () => new Body(
                             RequestBody(request)
+                        )
+                    ),
+                    new Parts.Conditional(
+                        () => request.HasFormContentType,
+                        () => new FormParams(
+                            RequestFormParams(request)
                         )
                     )
                 );
         }
 
-        private IInput RequestBody(HttpListenerRequest request)
+        private IMessageInput RequestAddress(HttpRequest request)
         {
-            using (var inStream = request.InputStream)
-            {
-                var outStream = new MemoryStream();
-                inStream.CopyTo(outStream); // read entire stream before it gets disposed
-                return new InputOf(outStream);
-            }
+            return
+                new Parts.Joined(
+                    new Scheme(request.Scheme.ToLower()),
+                    new Parts.Conditional(
+                        () => request.Host.HasValue,
+                        () => new Host(request.Host.Value)
+                    ),
+                    new Parts.Conditional(
+                        () => request.Host.HasValue && request.Host.Port != null,
+                        () => new Port((int)request.Host.Port)
+                    ),
+                    new Parts.Conditional(
+                        () => request.Path.HasValue,
+                        () => new Parts.Uri.Path(request.Path.Value)
+                    ),
+                    new Parts.Conditional(
+                        () => request.QueryString.HasValue,
+                        () => new QueryParams(request.QueryString.Value)
+                    )
+                );
+        }
+
+        private IEnumerable<IKvp> RequestHeaders(HttpRequest request)
+        {
+            return
+                new Atoms.Enumerable.Joined<IKvp>(
+                    new Mapped<string, IEnumerable<IKvp>>((key) =>
+                        new Mapped<string, IKvp>((value) =>
+                            new KvpOf(key, value),
+                            request.Headers[key]
+                        ),
+                        request.Headers.Keys
+                    )
+                );
+        }
+
+        private IInput RequestBody(HttpRequest request)
+        {
+            var stream = new MemoryStream();
+            request.BodyReader.AsStream().CopyTo(stream); // read entire stream before it gets disposed
+            stream.Position = 0;
+            return new InputOf(stream);
+        }
+
+        private IDictionary<string, string> RequestFormParams(HttpRequest request)
+        {
+            return
+                new MapOf(
+                    new Mapped<string, IKvp>((key) =>
+                        new KvpOf(key, request.Form[key]),
+                        request.Form.Keys
+                    )
+                );
         }
     }
 }

--- a/src/Yaapii.Http.Mock/Yaapii.Http.Mock.csproj
+++ b/src/Yaapii.Http.Mock/Yaapii.Http.Mock.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MockHttpServer" Version="1.4.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Yaapii.Http\Yaapii.Http.csproj" />
   </ItemGroup>
 

--- a/src/Yaapii.Http/Parts/Conditional.cs
+++ b/src/Yaapii.Http/Parts/Conditional.cs
@@ -32,8 +32,17 @@ namespace Yaapii.Http.Parts
         /// <summary>
         /// Only adds a part if a given condition applies.
         /// </summary>
-        public Conditional(Func<bool> condition, IMessageInput consequence) : base(dict => 
-            condition.Invoke() ? consequence.Apply(dict) : dict
+        public Conditional(Func<bool> condition, IMessageInput consequence) : this(
+            condition,
+            () => consequence
+        )
+        { }
+
+        /// <summary>
+        /// Only adds a part if a given condition applies.
+        /// </summary>
+        public Conditional(Func<bool> condition, Func<IMessageInput> consequence) : base(dict => 
+            condition.Invoke() ? consequence.Invoke().Apply(dict) : dict
         )
         { }
     }

--- a/tests/Test.Yaapii.Http/Parts/Bodies/BodyTests.cs
+++ b/tests/Test.Yaapii.Http/Parts/Bodies/BodyTests.cs
@@ -20,7 +20,6 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-using MockHttpServer;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Yaapii.Atoms;
@@ -180,18 +179,17 @@ namespace Yaapii.Http.Parts.Bodies.Test
             var port = new AwaitedPort(new TestPort()).Value();
             IInput result = new DeadInput();
             using (var server =
-                new MockServer(
-                    port,
-                    "{}",
-                    (req, res, prm) =>
+                new HttpMock(port,
+                    new FkWire((req) =>
+                    {
                         result =
                             new InputOf(
                                 new BytesOf(
-                                    new InputOf(req.InputStream)
+                                    new Body.Of(req)
                                 ).AsBytes()
-                            ),
-                    "localhost"
-                )
+                            );
+                    })
+                ).Value()
             )
             {
                 new AspNetCoreWire(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds (VisualStudio & cake script: build.ps1)
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or paste a link to an open issue -->
See #128 

### What is the new behavior?
<!-- Describe the new behavior -->
closes #128

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

The constructors of ```HttpMock``` no longer accept a "hostname" argument, so that will need to be removed from constructor calls. If you need a HttpMock that only reacts to a specific hostname, use a wire template that filters by the hostname:

```csharp
new HttpMock(port,
    new Match(
        new Host("localhost"),
        new FkWire(req =>
        {
            // do something ...
            return new Response.Of(200, "OK");
        })
    )
).Value()
```

Also, ```HttpMock.Value()``` previously returned a ```MockServer``` (see [MockHttpServer](https://github.com/jrharmon/MockHttpServer)), now it returns an ```IWebHost```. Any code relying the ```MockServer``` returned by ```HttpMock.Value()``` will need to be adapted.

Since the "normal" way to use ```HttpMock``` looks something like the following code, it likely doesn't need to be adapted, because only the ```using``` does anything (namely calling ```.Dispoe()```) with whatever is returned by ```HttpMock.Value()```:
```csharp
using (
    new HttpMock(port,
        new FkWire(req =>
        {
            // do something ...
            return new Response.Of(200, "OK");
        })
    ).Value()
)
{
    // more test code ...
}
```

###  Other information
depends on #126 
depends on #127 
